### PR TITLE
refactor: Switch to using bluebuild bin name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,4 +49,4 @@ runs:
         REGISTRY_TOKEN: ${{ inputs.registry_token }}
         PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
       run: |
-        bb build --push ./config/${{ inputs.recipe }}
+        bluebuild build --push ./config/${{ inputs.recipe }}


### PR DESCRIPTION
This will need to be merged in at the same time as the next BlueBuild release