### PR TITLE
fix: run build with cli container

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,17 +25,10 @@ runs:
     # clones user's repo
     - uses: actions/checkout@v4
 
-    - uses: sigstore/cosign-installer@v3.4.0
-
-    # pull self-contained binary program from installer image (outputs a bash install script)
-    - name: Install BlueBuild tool
-      shell: bash
-      run: podman run --rm ghcr.io/blue-build/cli:v0.7.0-installer | bash
-
     # deps used by cli to build & inspect imaegs
     - name: Install Dependencies
       shell: bash
-      run: sudo apt-get install -y buildah skopeo
+      run: sudo apt-get install -y podman
 
     # blue-build/cli does the heavy lifting
     - name: Build Image
@@ -45,4 +38,5 @@ runs:
         REGISTRY_TOKEN: ${{ inputs.registry_token }}
         PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
       run: |
-        bluebuild build --push ./config/${{ inputs.recipe }}
+        podman run --env-host --network=host --privileged --device /dev/fuse -v $PWD:/bluebuild ghcr.io/blue-build/cli:v0.7.1 \
+        build --push ./config/${{ inputs.recipe }} --registry ${{inputs.registry}} --registry-namespace ${{inputs.registry_namespace}}

--- a/action.yml
+++ b/action.yml
@@ -38,5 +38,5 @@ runs:
         REGISTRY_TOKEN: ${{ inputs.registry_token }}
         PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
       run: |
-        podman run --env-host --network=host --privileged --device /dev/fuse -v $PWD:/bluebuild ghcr.io/blue-build/cli:v0.7.1-alpine \
-        build --push ./config/${{ inputs.recipe }}
+        podman run --env-host --network=host --privileged --device /dev/fuse -v $PWD:/bluebuild \
+        ghcr.io/blue-build/cli:v0.7.1-alpine build --push ./config/${{ inputs.recipe }}

--- a/action.yml
+++ b/action.yml
@@ -39,4 +39,4 @@ runs:
         PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
       run: |
         podman run --env-host --network=host --privileged --device /dev/fuse -v $PWD:/bluebuild ghcr.io/blue-build/cli:v0.7.1 \
-        build --push ./config/${{ inputs.recipe }} --registry ${{inputs.registry}} --registry-namespace ${{inputs.registry_namespace}}
+        build --push ./config/${{ inputs.recipe }}

--- a/action.yml
+++ b/action.yml
@@ -38,5 +38,5 @@ runs:
         REGISTRY_TOKEN: ${{ inputs.registry_token }}
         PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
       run: |
-        podman run --env-host --network=host --privileged --device /dev/fuse -v $PWD:/bluebuild ghcr.io/blue-build/cli:v0.7.1 \
+        podman run --env-host --network=host --privileged --device /dev/fuse -v $PWD:/bluebuild ghcr.io/blue-build/cli:v0.7.1-alpine \
         build --push ./config/${{ inputs.recipe }}


### PR DESCRIPTION
This allows us to use newer buildah versions than what Ubuntu provides.

https://github.com/xynydev/linuXYZ/actions/runs/7940753849/job/21682371474

Thanks to @gerblesh for figuring out the args to use in #14 