### PR TITLE
feat: make maximizing build space optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
       Whether to run the unwanted software remover to maximize build space in the GitHub builder.
       Use this if your builds are taking too much space.
       Input must match the string "true" for the step to be enabled.
-    default: "false"
+    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -35,7 +35,7 @@ runs:
     # so it's best to remove unneeded softawre
     - name: Maximize build space
       uses: ublue-os/remove-unwanted-software@v6
-      if: ${{ inputs.maximize_build_space == "true" }}
+      if: ${{ inputs.maximize_build_space == 'true' }}
 
     # clones user's repo
     - uses: actions/checkout@v4

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
     description: |
       Whether to run the unwanted software remover to maximize build space in the GitHub builder.
       Use this if your builds are taking too much space.
-      Input must match the string "true" for the step to be enabled.
+      Input must match the string 'true' for the step to be enabled.
     default: 'false'
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,12 @@ inputs:
   pr_event_number:
     description: 'event number'
     required: true
+  maximize_build_space:
+    description: |
+      Whether to run the unwanted software remover to maximize build space in the GitHub builder.
+      Use this if your builds are taking too much space.
+      Input must match the string "true" for the step to be enabled.
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -29,6 +35,7 @@ runs:
     # so it's best to remove unneeded softawre
     - name: Maximize build space
       uses: ublue-os/remove-unwanted-software@v6
+      if: ${{ inputs.maximize_build_space == "true" }}
 
     # clones user's repo
     - uses: actions/checkout@v4


### PR DESCRIPTION
Reasoning: many users don't need this, but it takes kind of a longish time. #16 

Tested:
![image](https://github.com/blue-build/github-action/assets/60004820/75390c8b-65c6-439b-adcf-a5e2ce011be1)

So shaves off about 2 minutes from the start of the build, useful for debugging & such. Not that impactful with the current build times, but I think once the other thing related to #16 is merged that the 2 minutes will be a bigger portion of build time.