### PR TITLE
fix: use docker to build images (#16)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,14 @@ inputs:
      Example: `ublue-os`
     required: false
     default: ${{ github.repository_owner }}
+  use_cache:
+    description: |
+      Make use of docker buildx cache. This is an experimental feature of docker buildx
+      so it isn't guaranteed to work.
+      Input must match the string 'true' for the step to be enabled.
+    required: false
+    default: 'false'
+
 runs:
   using: "composite"
   steps:

--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,7 @@ runs:
       uses: docker/setup-buildx-action@v3
       with:
         install: true
+        driver: docker
         cache-binary: ${{ inputs.use_cache }}
 
     - name: Install BlueBuild

--- a/action.yml
+++ b/action.yml
@@ -65,22 +65,13 @@ runs:
       with:
         install: true
         driver: docker
-        cache-binary: ${{ inputs.use_cache }}
 
     - name: Install BlueBuild
       shell: bash
       env:
         # Uses GitHubs ternary syntax to set cli version, see https://docs.github.com/en/actions/learn-github-actions/expressions#example
         CLI_VERSION_TAG: ${{ inputs.use_unstable_cli == 'true' && 'main' || 'v0.8.2' }}
-      run: |
-        docker run \
-          --detach \
-          --rm \
-          --name blue-build-installer \
-          ghcr.io/blue-build/cli:${{ env.CLI_VERSION_TAG }}-installer \
-          tail -f /dev/null
-        docker cp blue-build-installer:/out/bluebuild /usr/local/bin/bluebuild
-        docker stop -t 0 blue-build-installer
+      run: podman run --rm ghcr.io/blue-build/cli:${CLI_VERSION_TAG}-installer | bash
 
     # clones user's repo
     - uses: actions/checkout@v4

--- a/action.yml
+++ b/action.yml
@@ -86,11 +86,6 @@ runs:
     - uses: actions/checkout@v4
     - uses: sigstore/cosign-installer@v3.4.0
 
-    # This is required in order to take advantage of docker's cache integration with GitHub Actions.experimental
-    # https://github.com/moby/buildkit?tab=readme-ov-file#github-actions-cache-
-    - name: Expose GitHub Runtime
-      if: ${{ inputs.use_cache == 'true' }}
-      uses: crazy-max/ghaction-github-runtime@v3
 
     # blue-build/cli does the heavy lifting
     - name: Build Image

--- a/action.yml
+++ b/action.yml
@@ -71,7 +71,15 @@ runs:
       env:
         # Uses GitHubs ternary syntax to set cli version, see https://docs.github.com/en/actions/learn-github-actions/expressions#example
         CLI_VERSION_TAG: ${{ inputs.use_unstable_cli == 'true' && 'main' || 'v0.8.2' }}
-      run: podman run --rm ghcr.io/blue-build/cli:${CLI_VERSION_TAG}-installer | bash
+      run: |
+        docker run \
+          --detach \
+          --rm \
+          --name blue-build-installer \
+          ghcr.io/blue-build/cli:${{ env.CLI_VERSION_TAG }}-installer \
+          tail -f /dev/null
+        docker cp blue-build-installer:/out/bluebuild /usr/local/bin/bluebuild
+        docker stop -t 0 blue-build-installer
 
     # clones user's repo
     - uses: actions/checkout@v4

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,6 @@ runs:
         COSIGN_PRIVATE_KEY: ${{ inputs.cosign_private_key }}
         GH_TOKEN: ${{ inputs.registry_token }}
         GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-        BB_BUILDKIT_CACHE_GHA: ${{ inputs.use_cache }}
       run: |
           bluebuild build -v --push ./config/${{ inputs.recipe }} \
           --registry ${{inputs.registry}} \

--- a/action.yml
+++ b/action.yml
@@ -90,6 +90,8 @@ runs:
     # clones user's repo
     - uses: actions/checkout@v4
 
+    # This is required in order to take advantage of docker's cache integration with GitHub Actions.experimental
+    # https://github.com/moby/buildkit?tab=readme-ov-file#github-actions-cache-
     - name: Expose GitHub Runtime
       if: ${{ inputs.use_cache == 'true' }}
       uses: crazy-max/ghaction-github-runtime@v3

--- a/action.yml
+++ b/action.yml
@@ -76,6 +76,7 @@ runs:
     - name: Install BlueBuild
       shell: bash
       env:
+        # Uses GitHubs ternary syntax to set cli version, see https://docs.github.com/en/actions/learn-github-actions/expressions#example
         CLI_VERSION_TAG: ${{ inputs.use_unstable_cli == 'true' && 'main' || 'v0.8.2' }}
       run: |
         docker run \
@@ -89,6 +90,7 @@ runs:
 
     # clones user's repo
     - uses: actions/checkout@v4
+    - uses: sigstore/cosign-installer@v3.4.0
 
     # This is required in order to take advantage of docker's cache integration with GitHub Actions.experimental
     # https://github.com/moby/buildkit?tab=readme-ov-file#github-actions-cache-

--- a/action.yml
+++ b/action.yml
@@ -50,13 +50,6 @@ inputs:
      Example: `ublue-os`
     required: false
     default: ${{ github.repository_owner }}
-  use_cache:
-    description: |
-      Make use of docker buildx cache. This is an experimental feature of docker buildx
-      so it isn't guaranteed to work.
-      Input must match the string 'true' for the step to be enabled.
-    required: false
-    default: 'false'
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -59,13 +59,32 @@ runs:
       uses: ublue-os/remove-unwanted-software@v6
       if: ${{ inputs.maximize_build_space == 'true' }}
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      with:
+        install: true
+        cache-binary: ${{ inputs.use_cache }}
+
+    - name: Install BlueBuild
+      shell: bash
+      env:
+        CLI_VERSION_TAG: ${{ inputs.use_unstable_cli == 'true' && 'main' || 'v0.8.2' }}
+      run: |
+        docker run \
+          --detach \
+          --rm \
+          --name blue-build-installer \
+          ghcr.io/blue-build/cli:${{ env.CLI_VERSION_TAG }}-installer \
+          tail -f /dev/null
+        docker cp blue-build-installer:/out/bluebuild /usr/local/bin/bluebuild
+        docker stop -t 0 blue-build-installer
+
     # clones user's repo
     - uses: actions/checkout@v4
 
-    # deps used by cli to build & inspect imaegs
-    - name: Install Dependencies
-      shell: bash
-      run: sudo apt-get install -y podman
+    - name: Expose GitHub Runtime
+      if: ${{ inputs.use_cache == 'true' }}
+      uses: crazy-max/ghaction-github-runtime@v3
 
     # blue-build/cli does the heavy lifting
     - name: Build Image
@@ -74,17 +93,8 @@ runs:
         COSIGN_PRIVATE_KEY: ${{ inputs.cosign_private_key }}
         GH_TOKEN: ${{ inputs.registry_token }}
         GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-        # Uses GitHubs ternary syntax to set cli version, see https://docs.github.com/en/actions/learn-github-actions/expressions#example
-        CLI_VERSION_TAG: ${{ inputs.use_unstable_cli == 'true' && 'main' || 'v0.8.2' }}
+        BB_BUILDKIT_CACHE_GHA: ${{ inputs.use_cache }}
       run: |
-        podman run \
-          -v buildah-vol:/var/run/containerd \
-          -v ${PWD}:/bluebuild \
-          --env-host \
-          --network=host \
-          --privileged \
-          --device /dev/fuse \
-          ghcr.io/blue-build/cli:${CLI_VERSION_TAG}-alpine \
-          build -vv --push ./config/${{ inputs.recipe }} \
-          --registry ${{ inputs.registry }} \
-          --registry-namespace ${{ inputs.registry_namespace }}
+          bluebuild build -vv --push ./config/${{ inputs.recipe }} \
+          --registry ${{inputs.registry}} \
+          --registry-namespace ${{inputs.registry_namespace}}

--- a/action.yml
+++ b/action.yml
@@ -107,6 +107,6 @@ runs:
         GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
         BB_BUILDKIT_CACHE_GHA: ${{ inputs.use_cache }}
       run: |
-          bluebuild build -vv --push ./config/${{ inputs.recipe }} \
+          bluebuild build -v --push ./config/${{ inputs.recipe }} \
           --registry ${{inputs.registry}} \
           --registry-namespace ${{inputs.registry_namespace}}


### PR DESCRIPTION
changes were made in the `testing` branch however the main branch hasn't been updated with docker builds. This PR includes the changes to build with docker and use a cache into the `main` version of the action