### PR TITLE
feat: Add ability to squash builds

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -152,7 +152,7 @@ runs:
         COSIGN_PRIVATE_KEY: ${{ inputs.cosign_private_key }}
         GH_TOKEN: ${{ inputs.registry_token }}
         GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-        CLI_VERSION_TAG: ${{ build_vars.output.cli-version }}
+        CLI_VERSION_TAG: ${{ steps.build_vars.output.cli-version }}
         RECIPE_PATH: ${{ steps.build_vars.output.recipe_path }}
       run: |
         podman run \

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,12 @@ inputs:
       Input must match the string 'true' for the step to be enabled.
     required: false
     default: 'true'
+  squash:
+    description: |
+      Uses buildah to squash the build's layers into a single layer. Use of this option
+      disables cache.
+    required: false
+    default: 'false'
 
 runs:
   using: "composite"
@@ -69,6 +75,7 @@ runs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      if: ${{ inputs.squash != 'true' }}
       with:
         install: true
         driver: docker-container
@@ -76,6 +83,7 @@ runs:
 
     - name: Install BlueBuild
       shell: bash
+      if: ${{ inputs.squash != 'true' }}
       env:
         # Uses GitHubs ternary syntax to set cli version, see https://docs.github.com/en/actions/learn-github-actions/expressions#example
         CLI_VERSION_TAG: ${{ inputs.use_unstable_cli == 'true' && 'main' || 'v0.8.4' }}
@@ -92,17 +100,19 @@ runs:
     # clones user's repo
     - uses: actions/checkout@v4
     - uses: sigstore/cosign-installer@v3.5.0
+      if: ${{ inputs.squash != 'true' }}
 
     # Required in order for docker buildx to
     # take advantage of the GHA cache API
     - name: Expose GitHub Runtime
-      if: ${{ inputs.use_cache == 'true' }}
+      if: ${{ inputs.use_cache == 'true' && inputs.squash != 'true' }}
       uses: crazy-max/ghaction-github-runtime@v3
 
 
     # blue-build/cli does the heavy lifting
     - name: Build Image
       shell: bash
+      if: ${{ inputs.squash != 'true' }}
       env:
         COSIGN_PRIVATE_KEY: ${{ inputs.cosign_private_key }}
         GH_TOKEN: ${{ inputs.registry_token }}
@@ -117,5 +127,36 @@ runs:
           RECIPE_PATH="./recipes/${RECIPE}"
         fi
         bluebuild build -v --push ${RECIPE_PATH} \
+          --registry ${{inputs.registry}} \
+          --registry-namespace ${{inputs.registry_namespace}}
+
+    - name: Build Squashed Image
+      shell: bash
+      if: ${{ inputs.squash == 'true' }}
+      env:
+        COSIGN_PRIVATE_KEY: ${{ inputs.cosign_private_key }}
+        GH_TOKEN: ${{ inputs.registry_token }}
+        GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
+        RECIPE: ${{ inputs.recipe }}
+        # Uses GitHubs ternary syntax to set cli version, see https://docs.github.com/en/actions/learn-github-actions/expressions#example
+        CLI_VERSION_TAG: ${{ inputs.use_unstable_cli == 'true' && 'main' || 'v0.8.4' }}
+      run: |
+        RECIPE_PATH=""
+        if [ -f "./config/${RECIPE}" ]; then
+          RECIPE_PATH="./config/${RECIPE}"
+        else
+          RECIPE_PATH="./recipes/${RECIPE}"
+        fi
+        podman run \
+          -v buildah-imagestores:/usr/lib/containers/storage \
+          -v buildah-graphroot:/var/lib/containers/storage \
+          -v buildah-runroot:/run/containers/storage \
+          -v $PWD:/bluebuild \
+          --env-host \
+          --network=host \
+          --privileged \
+          --device /dev/fuse \
+          ghcr.io/blue-build/cli:${CLI_VERSION_TAG}-alpine \
+          build -v -B buildah --squash --push ${RECIPE_PATH} \
           --registry ${{inputs.registry}} \
           --registry-namespace ${{inputs.registry_namespace}}

--- a/action.yml
+++ b/action.yml
@@ -109,7 +109,7 @@ runs:
       shell: bash
       if: ${{ inputs.squash != 'true' }}
       env:
-        CLI_VERSION_TAG: ${{ steps.build_vars.output.cli_version }}
+        CLI_VERSION_TAG: ${{ steps.build_vars.outputs.cli_version }}
       run: |
         docker run \
           --detach \
@@ -139,7 +139,7 @@ runs:
         GH_TOKEN: ${{ inputs.registry_token }}
         GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
         BB_BUILDKIT_CACHE_GHA: ${{ inputs.use_cache }}
-        RECIPE_PATH: ${{ steps.build_vars.output.recipe_path }}
+        RECIPE_PATH: ${{ steps.build_vars.outputs.recipe_path }}
       run: |
         bluebuild build -v --push ${RECIPE_PATH} \
           --registry ${{inputs.registry}} \
@@ -152,8 +152,8 @@ runs:
         COSIGN_PRIVATE_KEY: ${{ inputs.cosign_private_key }}
         GH_TOKEN: ${{ inputs.registry_token }}
         GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-        CLI_VERSION_TAG: ${{ steps.build_vars.output.cli_version }}
-        RECIPE_PATH: ${{ steps.build_vars.output.recipe_path }}
+        CLI_VERSION_TAG: ${{ steps.build_vars.outputs.cli_version }}
+        RECIPE_PATH: ${{ steps.build_vars.outputs.recipe_path }}
       run: |
         podman run \
           -v buildah-imagestores:/usr/lib/containers/storage \

--- a/action.yml
+++ b/action.yml
@@ -109,7 +109,7 @@ runs:
       shell: bash
       if: ${{ inputs.squash != 'true' }}
       env:
-        CLI_VERSION_TAG: ${{ build_vars.output.cli-version }}
+        CLI_VERSION_TAG: ${{ steps.build_vars.output.cli-version }}
       run: |
         docker run \
           --detach \
@@ -139,7 +139,7 @@ runs:
         GH_TOKEN: ${{ inputs.registry_token }}
         GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
         BB_BUILDKIT_CACHE_GHA: ${{ inputs.use_cache }}
-        RECIPE_PATH: ${{ build_vars.output.recipe_path }}
+        RECIPE_PATH: ${{ steps.build_vars.output.recipe_path }}
       run: |
         bluebuild build -v --push ${RECIPE_PATH} \
           --registry ${{inputs.registry}} \
@@ -153,7 +153,7 @@ runs:
         GH_TOKEN: ${{ inputs.registry_token }}
         GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
         CLI_VERSION_TAG: ${{ build_vars.output.cli-version }}
-        RECIPE_PATH: ${{ build_vars.output.recipe_path }}
+        RECIPE_PATH: ${{ steps.build_vars.output.recipe_path }}
       run: |
         podman run \
           -v buildah-imagestores:/usr/lib/containers/storage \

--- a/action.yml
+++ b/action.yml
@@ -93,7 +93,7 @@ runs:
         if [[ "${{ inputs.use_unstable_cli }}" == "true" ]]; then
           CLI_VERSION_TAG="main"
         else
-          CLI_VERSION_TAG="v0.8.5"
+          CLI_VERSION_TAG="v0.8"
         fi
         echo "cli_version=${CLI_VERSION_TAG}" >> ${GITHUB_OUTPUT}
 

--- a/action.yml
+++ b/action.yml
@@ -109,7 +109,7 @@ runs:
       shell: bash
       if: ${{ inputs.squash != 'true' }}
       env:
-        CLI_VERSION_TAG: ${{ steps.build_vars.output.cli-version }}
+        CLI_VERSION_TAG: ${{ steps.build_vars.output.cli_version }}
       run: |
         docker run \
           --detach \
@@ -152,7 +152,7 @@ runs:
         COSIGN_PRIVATE_KEY: ${{ inputs.cosign_private_key }}
         GH_TOKEN: ${{ inputs.registry_token }}
         GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-        CLI_VERSION_TAG: ${{ steps.build_vars.output.cli-version }}
+        CLI_VERSION_TAG: ${{ steps.build_vars.output.cli_version }}
         RECIPE_PATH: ${{ steps.build_vars.output.recipe_path }}
       run: |
         podman run \

--- a/action.yml
+++ b/action.yml
@@ -81,12 +81,35 @@ runs:
         driver: docker-container
         cache-binary: ${{ inputs.use_cache }}
 
+    # clones user's repo
+    - uses: actions/checkout@v4
+
+    - name: Determine Vars
+      id: build_vars
+      shell: bash
+      env:
+        RECIPE: ${{ inputs.recipe }}
+      run: |
+        if [[ "${{ inputs.use_unstable_cli }}" == "true" ]]; then
+          CLI_VERSION_TAG="main"
+        else
+          CLI_VERSION_TAG="v0.8.4"
+        fi
+        echo "cli_version=${CLI_VERSION_TAG}" >> ${GITHUB_OUTPUT}
+
+        RECIPE_PATH=""
+        if [ -f "./config/${RECIPE}" ]; then
+          RECIPE_PATH="./config/${RECIPE}"
+        else
+          RECIPE_PATH="./recipes/${RECIPE}"
+        fi
+        echo "recipe_path=${RECIPE_PATH}" >> ${GITHUB_OUTPUT}
+
     - name: Install BlueBuild
       shell: bash
       if: ${{ inputs.squash != 'true' }}
       env:
-        # Uses GitHubs ternary syntax to set cli version, see https://docs.github.com/en/actions/learn-github-actions/expressions#example
-        CLI_VERSION_TAG: ${{ inputs.use_unstable_cli == 'true' && 'main' || 'v0.8.4' }}
+        CLI_VERSION_TAG: ${{ build_vars.output.cli-version }}
       run: |
         docker run \
           --detach \
@@ -97,8 +120,6 @@ runs:
         docker cp blue-build-installer:/out/bluebuild /usr/local/bin/bluebuild
         docker stop -t 0 blue-build-installer
 
-    # clones user's repo
-    - uses: actions/checkout@v4
     - uses: sigstore/cosign-installer@v3.5.0
       if: ${{ inputs.squash != 'true' }}
 
@@ -117,15 +138,9 @@ runs:
         COSIGN_PRIVATE_KEY: ${{ inputs.cosign_private_key }}
         GH_TOKEN: ${{ inputs.registry_token }}
         GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-        RECIPE: ${{ inputs.recipe }}
         BB_BUILDKIT_CACHE_GHA: ${{ inputs.use_cache }}
+        RECIPE_PATH: ${{ build_vars.output.recipe_path }}
       run: |
-        RECIPE_PATH=""
-        if [ -f "./config/${RECIPE}" ]; then
-          RECIPE_PATH="./config/${RECIPE}"
-        else
-          RECIPE_PATH="./recipes/${RECIPE}"
-        fi
         bluebuild build -v --push ${RECIPE_PATH} \
           --registry ${{inputs.registry}} \
           --registry-namespace ${{inputs.registry_namespace}}
@@ -137,16 +152,9 @@ runs:
         COSIGN_PRIVATE_KEY: ${{ inputs.cosign_private_key }}
         GH_TOKEN: ${{ inputs.registry_token }}
         GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-        RECIPE: ${{ inputs.recipe }}
-        # Uses GitHubs ternary syntax to set cli version, see https://docs.github.com/en/actions/learn-github-actions/expressions#example
-        CLI_VERSION_TAG: ${{ inputs.use_unstable_cli == 'true' && 'main' || 'v0.8.4' }}
+        CLI_VERSION_TAG: ${{ build_vars.output.cli-version }}
+        RECIPE_PATH: ${{ build_vars.output.recipe_path }}
       run: |
-        RECIPE_PATH=""
-        if [ -f "./config/${RECIPE}" ]; then
-          RECIPE_PATH="./config/${RECIPE}"
-        else
-          RECIPE_PATH="./recipes/${RECIPE}"
-        fi
         podman run \
           -v buildah-imagestores:/usr/lib/containers/storage \
           -v buildah-graphroot:/var/lib/containers/storage \

--- a/action.yml
+++ b/action.yml
@@ -93,7 +93,7 @@ runs:
         if [[ "${{ inputs.use_unstable_cli }}" == "true" ]]; then
           CLI_VERSION_TAG="main"
         else
-          CLI_VERSION_TAG="v0.8.4"
+          CLI_VERSION_TAG="v0.8.5"
         fi
         echo "cli_version=${CLI_VERSION_TAG}" >> ${GITHUB_OUTPUT}
 


### PR DESCRIPTION
Trying to support an older version of `buildah` and `podman` proved too difficult. Instead we'll just run the build inside a container. From my own testing with the squash builds, when you run `buildah`/`podman` inside a container, the builds can be incredibly slow with all the multi-stages and mounts on the `RUN` instructions. However, activating squash (`--layers=false`) the build runs just as fast as normal. Activating the squash feature will by default not make use of any cache abilities.