### PR TITLE
feat: support changing working directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,12 @@ inputs:
       disables cache.
     required: false
     default: 'false'
+  working_directory:
+    description: |
+      Changes working directory for whole build.
+      For example, setting this to `./abc/` would cause for the recipe to be read from `./abc/recipes/recipe.yml`.
+    required: false
+    default: ./
 
 runs:
   using: "composite"
@@ -134,6 +140,7 @@ runs:
     - name: Build Image
       shell: bash
       if: ${{ inputs.squash != 'true' }}
+      working-directory: ${{ inputs.working_directory }}
       env:
         COSIGN_PRIVATE_KEY: ${{ inputs.cosign_private_key }}
         GH_TOKEN: ${{ inputs.registry_token }}
@@ -148,6 +155,7 @@ runs:
     - name: Build Squashed Image
       shell: bash
       if: ${{ inputs.squash == 'true' }}
+      working-directory: ${{ inputs.working_directory }}
       env:
         COSIGN_PRIVATE_KEY: ${{ inputs.cosign_private_key }}
         GH_TOKEN: ${{ inputs.registry_token }}


### PR DESCRIPTION
This feature could be used to structure a repo, like I'm planning with the [examples repo](https://github.com/blue-build/examples), such that there are multiple subdirectories each with their own `recipes/`, `configs/` etc. folders.