### PR TITLE
fix: Default maximize_build_space to true

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,10 +33,9 @@ inputs:
   maximize_build_space:
     description: |
       Whether to run the unwanted software remover to maximize build space in the GitHub builder.
-      Use this if your builds are taking too much space.
-      Input must match the string 'true' for the step to be enabled.
+      Disable this with 'false' if your image doesn't take up a lot of space and you'd rather have shorter build times.
     required: false
-    default: 'false'
+    default: 'true'
   use_unstable_cli:
     description: |
       If true, this action pulls the `main` branch of blue-build/cli instead of the stable version the current action version is configured to use by default. 


### PR DESCRIPTION
This comes as a realization that we've had many several users run into this issue only to be told they need to change an input for the action. I feel that defaulting this to true is a saner default if only to allow users to build without eventually running into this problem as they increase their image size. It seems to confuse more than help with default false.