### PR TITLE
feat: allow skipping the checkout step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -81,8 +81,8 @@ inputs:
   skip_checkout:
       description: |
         Set to true to skip doing the actions/checkout step.
-        This allows you to checkout before calling bluebuild/github-action and modify files
-        (such as supplying build information to other scripts) before building.
+        This allows you to checkout manually before calling bluebuild/github-action
+        and to modify files (such as supplying build information to other scripts) before building.
       required: false
       default: 'false'
 

--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,13 @@ inputs:
       For example, setting this to `./abc/` would cause for the recipe to be read from `./abc/recipes/recipe.yml`.
     required: false
     default: ./
+  skip_checkout:
+      description: |
+        Set to true to skip doing the actions/checkout step.
+        This allows you to checkout before calling bluebuild/github-action and modify files
+        (such as supplying build information to other scripts) before building.
+      required: false
+      default: 'false'
 
 runs:
   using: "composite"
@@ -122,6 +129,7 @@ runs:
 
     # clones user's repo
     - uses: actions/checkout@v4
+      if: ${{ inputs.skip_checkout == 'false' }}
 
     - name: Determine Vars
       id: build_vars


### PR DESCRIPTION
This adds a flag to the inputs that will cause the action to skip running a checkout. This allows end users to modify the state of their repository files with dynamic information such as branch, commit hash, and more before building their images.

Might be a fix/implementation for #53.