### PR TITLE
feat: allow providing options to `bluebuild build` command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,9 +69,16 @@ inputs:
   squash:
     description: |
       Uses buildah to squash the build's layers into a single layer. Use of this option
-      disables cache.
+      disables cache. Conflicts with adding --build-driver or --squash to the build opts.
     required: false
     default: 'false'
+  build_opts:
+    description: |
+      Provides options to the call to the call to bluebuild build. If you use with
+      the squash input set to true and provide a --build-driver or --squash option
+      an error will occur and the action will not run.
+    required: false
+    default: ' '
   working_directory:
     description: |
       Changes working directory for whole build.
@@ -89,6 +96,12 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Validate inputs
+      shell: bash
+      run: "${{ github.action_path }}/build_opts_check.sh"
+      env:
+        SQUASH_INPUT_VALUE: "${{ inputs.squash }}"
+        BUILD_OPTS: "${{ inputs.build_opts }}"
     # building custom images might take a lot of space, 
     # so it's best to remove unneeded softawre
     - name: Maximize build space
@@ -189,9 +202,8 @@ runs:
         RECIPE_PATH: ${{ steps.build_vars.outputs.recipe_path }}
         RUST_LOG_STYLE: always
         CLICOLOR_FORCE: '1'
+        BUILD_OPTS: ${{ inputs.build_opts }}
       run: |
-        BUILD_OPTS=""
-
         if [ "${{ inputs.squash }}" = "true" ]; then
           BUILD_OPTS="--build-driver podman --squash $BUILD_OPTS"
         fi

--- a/action.yml
+++ b/action.yml
@@ -74,8 +74,8 @@ inputs:
     default: 'false'
   build_opts:
     description: |
-      Provides options to the call to the call to bluebuild build. If you use with
-      the squash input set to true and provide a --build-driver or --squash option
+      Provide options to the call to the BlueBuild CLI build command. If you use this with
+      the squash input set to true and provide either of the --build-driver or --squash flags
       an error will occur and the action will not run.
     required: false
     default: ' '

--- a/build_opts_check.sh
+++ b/build_opts_check.sh
@@ -1,24 +1,23 @@
 #!/bin/bash
 
 # Expected env vars:
-# SQUASH_INPUT_VALUER
+# SQUASH_INPUT_VALUE
 # BUILD_OPTS
 
 if [ "$SQUASH_INPUT_VALUE" != "true" ]; then
   if grep -qE '(-B)|(--build-driver)' <<< "$BUILD_OPTS"; then
-    echo 'Cannot provide --build-driver in build_opts while squash = true'
+    echo 'Cannot provide --build-driver in build_opts while squash is set to true.'
     exit 1
   fi
 
   if grep -qE '(-s)|(--squash)' <<< "$BUILD_OPTS"; then
-    echo 'Cannot provide --squash in build_opts while squash = true'
+    echo 'Cannot provide --squash in build_opts while squash is set to true.'
     exit 1
   fi
 fi
 
 if grep -qE '(-p)|(--push)' <<< "$BUILD_OPTS"; then
-  echo 'Please do not provide --push in build_opts as the action provides it' \
-    ' by default anyway.'
+  echo 'Please do not add --push to build_opts, as the action already provides that argument.'
   exit 1
 fi
 

--- a/build_opts_check.sh
+++ b/build_opts_check.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Expected env vars:
+# SQUASH_INPUT_VALUER
+# BUILD_OPTS
+
+if [ "$SQUASH_INPUT_VALUE" != "true" ]; then
+  if grep -qE '(-B)|(--build-driver)' <<< "$BUILD_OPTS"; then
+    echo 'Cannot provide --build-driver in build_opts while squash = true'
+    exit 1
+  fi
+
+  if grep -qE '(-s)|(--squash)' <<< "$BUILD_OPTS"; then
+    echo 'Cannot provide --squash in build_opts while squash = true'
+    exit 1
+  fi
+fi
+
+if grep -qE '(-p)|(--push)' <<< "$BUILD_OPTS"; then
+  echo 'Please do not provide --push in build_opts as the action provides it' \
+    ' by default anyway.'
+  exit 1
+fi
+
+exit 0

--- a/build_opts_check.sh
+++ b/build_opts_check.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Expected env vars:
 # SQUASH_INPUT_VALUE


### PR DESCRIPTION
This creates a `build_opts` input along with some basic validation to ensure that duplicate options are not passed to `buildbuild build`.

- [x] Add a new input for the action called build_opts
  * Pass that as the BUILD_OPTS environment variable to the image build step
  * Remove the line BUILD_OPTS="" (or it might need to be made conditional depending on whether the input has been added)
    * The input defaults to a single space. This allows us to pass it into the environment unconditionally.
    * Validation step prevents the action running with duplicate arguments.
    * For remaining arguments, `bluebuild build` errors should mention arguments explicitly added by the user as being the problem. So they should not be caught completely unawares that --nonexistent-arg is the problem.
- Do testing based on your custom branch, at least these two scenarios
  - [x] Is BUILD_OPTS empty if you pass nothing into the build_opts input? (Build)[
  - Is it possible to break the build by adding some opts that conflict with what is automatically configured?
    - Yes. The build_opts and squash values are passed into a validation script that will exit with a non-zero status should the combination of inputs result in duplicate arguments. It also checks for `-p` or `--push` since the action provides that option by default.
  - [x] Maybe we'd want to do an error message that points out that your custom build opts might be the issue in case of a build failure. 
    - [Builds fail fast at an initial validation step that explains what's wrong.](https://github.com/dkolb/bazzite-dkub/actions/runs/11759119476/job/32758248160#step:4:25)
    - [Checking for --push/-p even when squash is false](https://github.com/dkolb/bazzite-dkub/actions/runs/11759206228/job/32758422647#step:4:25)
  - [x] (of course try testing whether the input works for its actual use case too) [Successful build using zstd compression](https://github.com/dkolb/bazzite-dkub/actions/runs/11759083601/job/32758205162#step:4:9)
