### PR TITLE
feat: add `log_path` output for the action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,14 +13,14 @@ inputs:
       Example: `&#36;{{ secrets.SIGNING_SECRET }}`
     required: true
   registry_token:
-    description: | 
+    description: |
       The token used to sign into the container registry.
 
       Example: `&#36;{{ github.token }}`
     required: false
     default: ''
   registry_username:
-    description: | 
+    description: |
       The username used to sign into the container registry.
     required: false
     default: ${{ github.repository_owner }}
@@ -38,7 +38,7 @@ inputs:
     default: 'true'
   use_unstable_cli:
     description: |
-      If true, this action pulls the `main` branch of blue-build/cli instead of the stable version the current action version is configured to use by default. 
+      If true, this action pulls the `main` branch of blue-build/cli instead of the stable version the current action version is configured to use by default.
       This feature is useful for testing new features, but should not be used in production.
       Input must match the string 'true' for the unstable version to be used.
     required: false
@@ -55,7 +55,7 @@ inputs:
   registry_namespace:
     description: |
      The namespace on the registry to push to.
-     
+
      Example: `ublue-os`
     required: false
     default: ${{ github.repository_owner }}
@@ -92,6 +92,10 @@ inputs:
         and to modify files (such as supplying build information to other scripts) before building.
       required: false
       default: 'false'
+outputs:
+  log_path:
+    description: Directory containing logs of `bluebuild build`
+    value: ${{ steps.build_image.outputs.log_path }}
 
 runs:
   using: "composite"
@@ -102,7 +106,7 @@ runs:
       env:
         SQUASH_INPUT_VALUE: "${{ inputs.squash }}"
         BUILD_OPTS: "${{ inputs.build_opts }}"
-    # building custom images might take a lot of space, 
+    # building custom images might take a lot of space,
     # so it's best to remove unneeded softawre
     - name: Maximize build space
       uses: jlumbroso/free-disk-space@v1.3.1
@@ -188,6 +192,7 @@ runs:
 
     # blue-build/cli does the heavy lifting
     - name: Build Image
+      id: build_image
       shell: bash
       working-directory: ${{ inputs.working_directory }}
       env:
@@ -208,4 +213,6 @@ runs:
           BUILD_OPTS="--build-driver podman --squash $BUILD_OPTS"
         fi
 
-        bluebuild build -v --push ${BUILD_OPTS} ${RECIPE_PATH}
+        LOGDIR=$(mktemp -d -u "${RUNNER_TMP}/bluebuild-log-XXXXX")
+        bluebuild --log-out=${LOGDIR} build -v --push ${BUILD_OPTS} ${RECIPE_PATH}
+        echo "log_path=${LOGDIR}" >> ${GITHUB_OUTPUT}


### PR DESCRIPTION
It contains logs of the `bluebuild build` as created via `--log-out`.

This is a crutch/workaround for https://github.com/blue-build/cli/issues/263, but might be useful for general public. The logs are saved under `${RUNNER_TMP}`, with a unique directory name for every run. 