### PR TITLE
chore: bump cosign-installer to v3.8.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -147,7 +147,7 @@ runs:
         sudo apt-get update
         sudo apt-get install -y podman
 
-    - uses: sigstore/cosign-installer@v3.8.0
+    - uses: sigstore/cosign-installer@v3.8.1
       with:
         install-dir: /usr/bin
         use-sudo: true


### PR DESCRIPTION
https://github.com/sigstore/cosign-installer/releases/tag/v3.8.1