### PR TITLE
feat: add retry_push_count option to expose retry-push CLI options

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ inputs:
     default: "true"
   use_unstable_cli:
     description: |
-      If true, this action pulls the `main` branch of blue-build/cli instead of the stable version the current action version is configured to use by default. 
+      If true, this action pulls the `main` branch of blue-build/cli instead of the stable version the current action version is configured to use by default.
       This feature is useful for testing new features, but should not be used in production.
       Input must match the string 'true' for the unstable version to be used.
     required: false
@@ -73,6 +73,11 @@ inputs:
       Make use of layer cache by pushing the layers to the registry. Input must match the string 'true' for the step to be enabled.
     required: false
     default: "false"
+  retry_push_count:
+    description: |
+      The number of times to retry pushing the image.
+    required: false
+    default: 0
   squash:
     description: |
       Uses buildah to squash the build's layers into a single layer. Use of this option
@@ -105,10 +110,13 @@ runs:
   steps:
     - name: Validate inputs
       shell: bash
-      run: "${{ github.action_path }}/build_opts_check.sh"
       env:
-        SQUASH_INPUT_VALUE: "${{ inputs.squash }}"
-        BUILD_OPTS: "${{ inputs.build_opts }}"
+        SQUASH_INPUT_VALUE: ${{ inputs.squash }}
+        BUILD_OPTS: ${{ inputs.build_opts }}
+        github_action_path: ${{ github.action_path }}
+      run: |
+        "${github_action_path}/build_opts_check.sh"
+
     # building custom images might take a lot of space,
     # so it's best to remove unneeded softawre
     - name: Maximize build space
@@ -129,7 +137,7 @@ runs:
       run: |
         VERSION=$(awk -F= '/^VERSION_ID=/ {gsub(/"/, "", $2); print $2}' /etc/os-release)
         echo "Ubuntu version is $VERSION"
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
     # that is compatible with BlueBuild
     - name: Setup Podman
@@ -140,8 +148,8 @@ runs:
         ubuntu_version='22.04'
         key_url="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key"
         sources_url="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}"
-        echo "deb $sources_url/ /" | sudo tee /etc/apt/sources.list.d/devel-kubic-libcontainers-unstable.list
-        curl -fsSL $key_url | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_unstable.gpg > /dev/null
+        echo "deb ${sources_url}/ /" | sudo tee /etc/apt/sources.list.d/devel-kubic-libcontainers-unstable.list
+        curl -fsSL "${key_url}" | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_unstable.gpg > /dev/null
         sudo apt-get update
         sudo apt-get install -y podman
 
@@ -151,23 +159,27 @@ runs:
         use-sudo: true
 
     # clones user's repo
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       if: ${{ inputs.skip_checkout == 'false' }}
+      with:
+        persist-credentials: false
 
     - name: Determine Vars
       id: build_vars
       shell: bash
       env:
         RECIPE: ${{ inputs.recipe }}
+        USE_UNSTABLE_CLI: ${{ inputs.use_unstable_cli }}
+        CLI_VERSION: ${{ inputs.cli_version }}
       run: |
-        if [[ "${{ inputs.use_unstable_cli }}" == "true" && -z "${{ inputs.cli_version }}" ]]; then
+        if [[ "${USE_UNSTABLE_CLI}" == "true" && -z "${CLI_VERSION}" ]]; then
           CLI_VERSION_TAG="main"
-        elif [ -n "${{ inputs.cli_version }}" ]; then
-          CLI_VERSION_TAG="${{ inputs.cli_version }}"
+        elif [ -n "${CLI_VERSION}" ]; then
+          CLI_VERSION_TAG="${CLI_VERSION}"
         else
           CLI_VERSION_TAG="v0.9"
         fi
-        echo "cli_version=${CLI_VERSION_TAG}" >> ${GITHUB_OUTPUT}
+        echo "cli_version=${CLI_VERSION_TAG}" >> "${GITHUB_OUTPUT}"
 
         RECIPE_PATH=""
         if [ -f "./config/${RECIPE}" ]; then
@@ -175,7 +187,7 @@ runs:
         else
           RECIPE_PATH="./recipes/${RECIPE}"
         fi
-        echo "recipe_path=${RECIPE_PATH}" >> ${GITHUB_OUTPUT}
+        echo "recipe_path=${RECIPE_PATH}" >> "${GITHUB_OUTPUT}"
 
     - name: Install BlueBuild
       shell: bash
@@ -184,7 +196,7 @@ runs:
       run: |
         sudo docker create \
           --name blue-build-installer \
-          ghcr.io/blue-build/cli:${{ env.CLI_VERSION_TAG }}-installer
+          "ghcr.io/blue-build/cli:${CLI_VERSION_TAG}-installer"
         sudo docker cp blue-build-installer:/out/bluebuild /usr/bin/bluebuild
         sudo docker rm blue-build-installer
         bluebuild --version
@@ -202,23 +214,30 @@ runs:
         BB_REGISTRY_NAMESPACE: ${{ inputs.registry_namespace }}
         GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
         BB_CACHE_LAYERS: ${{ inputs.use_cache }}
+        BB_RETRY_PUSH_COUNT: ${{ inputs.retry_push_count }}
+        BB_SQUASH: ${{ inputs.squash }}
+        BB_RECHUNK: ${{ inputs.rechunk }}
         RECIPE_PATH: ${{ steps.build_vars.outputs.recipe_path }}
         RUST_LOG_STYLE: always
         CLICOLOR_FORCE: "1"
         BUILD_OPTS: ${{ inputs.build_opts }}
       run: |
-        if [ "${{ inputs.squash }}" = "true" ]; then
-          BUILD_OPTS="--build-driver podman --squash $BUILD_OPTS"
+        if [ "${BB_SQUASH}" = "true" ]; then
+          BUILD_OPTS="--build-driver podman --squash ${BUILD_OPTS}"
         fi
 
         RUN_SUDO=""
-        if [ "${{ inputs.rechunk }}" = "true" ]; then
+        if [ "${BB_RECHUNK}" = "true" ]; then
           RUN_SUDO=1
-          BUILD_OPTS="--rechunk $BUILD_OPTS"
+          BUILD_OPTS="--rechunk ${BUILD_OPTS}"
+        fi
+
+        if [ "${BB_RETRY_PUSH_COUNT}" != '0' ]; then
+          BUILD_OPTS="--retry-push --retry-count '${BB_RETRY_PUSH_COUNT}' ${BUILD_OPTS}"
         fi
 
         if [ -n "$RUN_SUDO" ]; then
-          sudo -E bluebuild build -v --push ${BUILD_OPTS} ${RECIPE_PATH}
+          sudo -E bluebuild build -v --push ${BUILD_OPTS} "${RECIPE_PATH}"
         else
-          bluebuild build -v --push ${BUILD_OPTS} ${RECIPE_PATH}
+          bluebuild build -v --push ${BUILD_OPTS} "${RECIPE_PATH}"
         fi


### PR DESCRIPTION
It's reasonably common for the image pushing step to fail in CI due to transient network issues, so it makes sense to expose the `--retry-push` and `--retry-count` options in the GitHub action. This adds a `retry_push_count` option to the action that defaults to 0, and if set to be nonzero, it enables `--retry-push` and passes the retry count to the CLI.

I also did a bit of minor cleanup of the action:
* Updated actions/checkout to v5.0.0.
* Added `persist-credentials: false` to actions/checkout for security, per [Zizmor](https://docs.zizmor.sh/) recommendation.
* Converted direct template expansions (which are potentially vulnerable to code injection attacks) into environment variables.
* Quoted shell variables to prevent unintended shell splitting.