### PR TITLE
fix logic error in checks: squash check is inverted

### DIFF
--- a/build_opts_check.sh
+++ b/build_opts_check.sh
@@ -26,7 +26,7 @@ check_build_opts() {
     fi
 }
 
-if [[ "${SQUASH_INPUT_VALUE}" != "true" ]]; then
+if [[ "${SQUASH_INPUT_VALUE}" == "true" ]]; then
   check_build_opts "-B" "--build-driver" "Cannot provide '--build-driver' in build_opts while 'squash' is set to true."
   check_build_opts "-s" "--squash" "Cannot provide '--squash' in build_opts while 'squash' is set to true."
 fi


### PR DESCRIPTION
The squash check in `build_opts_check.sh` is incorrect, leading to failures whenever any `build_opts` are specified