### PR TITLE
chore: Add gmpinder to CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @xynydev
+* @xynydev @gmpinder


### PR DESCRIPTION
I've made significant changes to this repo so I'd like to be added as a CODEOWNER since @xynydev is not always around.