### PR TITLE
fix: typo in input validation step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -129,7 +129,7 @@ runs:
       shell: bash
       env:
         INPUT_BUILD_CHUNKED_OCI: ${{ inputs.build_chunked_oci }}
-        INPUT_RECHUNK: ${{ inputs.build_chunked_oci }}
+        INPUT_RECHUNK: ${{ inputs.rechunk }}
         INPUT_SQUASH: ${{ inputs.squash }}
         BUILD_OPTS: ${{ inputs.build_opts }}
         github_action_path: ${{ github.action_path }}


### PR DESCRIPTION
The wrong input was being passed to `INPUT_RECHUNK`.