### PR TITLE
chore: replace unmaintained free-disk-space action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -139,7 +139,7 @@ runs:
     # building custom images might take a lot of space,
     # so it's best to remove unneeded softawre
     - name: Maximize build space
-      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+      uses: hastd/free-disk-space@5c7d2a3a2111207998da95cb27f78ef9d5982abd # v0.1.0
       if: ${{ inputs.maximize_build_space == 'true' }}
 
     - name: Set up Docker Buildx


### PR DESCRIPTION
The [jlumbroso/free-disk-space](https://github.com/jlumbroso/free-disk-space) action is unmaintained (no commits in over 2 years). I made a GitHub action at [hastd/free-disk-space](https://github.com/HastD/free-disk-space) that serves the same purpose while being up-to-date, running significantly faster, and saving more space.

Resolves #116.