### PR TITLE
chore: Remove deprecated install option for docker/setup-buildx-action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -157,7 +157,6 @@ runs:
       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       if: ${{ inputs.squash != 'true' && inputs.build_chunked_oci != 'true' && inputs.rechunk != 'true' }}
       with:
-        install: true
         driver: docker-container
         cache-binary: ${{ inputs.use_cache }}
 


### PR DESCRIPTION
This option is deprecated now and not needed since we already make use of `buildx` directly.

<img width="1759" height="772" alt="image" src="https://github.com/user-attachments/assets/f7c98d92-277e-486f-8937-56d0e122f48e" />

Closes https://github.com/blue-build/github-action/issues/134