### PR TITLE
feat: support providing the cosign public key via GitHub Secrets

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,7 @@ inputs:
 
       Example: `&#36;{{ secrets.COSIGN_PUBLIC_KEY }}`
     required: false
+    default: ""
 
   push:
     description: |

--- a/action.yml
+++ b/action.yml
@@ -10,8 +10,16 @@ inputs:
     description: |
       The Sigstore/cosign secret used to sign the image.
 
-      Example: `&#36;{{ secrets.SIGNING_SECRET }}`
+      Example: `&#36;{{ secrets.COSIGN_PRIVATE_KEY }}`
     required: true
+
+  cosign_public_key:
+    description: |
+      The public key, but passed as env.
+
+      Example: `&#36;{{ secrets.COSIGN_PUBLIC_KEY }}`
+    required: false
+
   push:
     description: |
       Whether to push the image to a container registry.
@@ -330,6 +338,7 @@ runs:
       working-directory: ${{ inputs.working_directory }}
       env:
         COSIGN_PRIVATE_KEY: ${{ inputs.cosign_private_key }}
+        COSIGN_PUBLIC_KEY: ${{ inputs.cosign_public_key }}
         GH_TOKEN: ${{ inputs.registry_token }}
         BB_BUILD_PUSH: ${{ inputs.push }}
         BB_PASSWORD: ${{ inputs.registry_token }}
@@ -352,6 +361,12 @@ runs:
         BUILD_OPTS: ${{ inputs.build_opts }}
       run: |
         read -r -a BUILD_OPTS <<< "${BUILD_OPTS}"
+
+        # Create a temporary cosign.pub from the secret if one isn't already present,
+        # a way to avoid committing any type of credential—public or private—directly to the repository
+        if [[ ! -f cosign.pub && -n "${COSIGN_PUBLIC_KEY:-}" ]]; then
+            printf '%s\n' "${COSIGN_PUBLIC_KEY}" > cosign.pub
+        fi
 
         boolean_variables=(
           BB_BUILD_PUSH


### PR DESCRIPTION
### Summary

This removes the need to store `cosign.pub` in the repository by allowing the public key to be provided through GitHub Secrets.

The current approach can create unnecessary conflicts for forks and downstream repositories, since `cosign.pub` becomes a tracked file that must be replaced whenever a different signing key is used.

I encountered this while maintaining multiple repositories with independent signing identities. A cloned or forked repository required replacing `cosign.pub`, causing persistent diffs and potential merge conflicts unrelated to the actual code changes.

This change preserves full backward compatibility:

* If `cosign.pub` exists in the repository, the current behavior is unchanged.
* If the file is absent and `cosign_public_key` is provided, the action creates a temporary `cosign.pub` file during the workflow execution.

The implementation is intentionally minimal, requiring only:

* One optional input (`cosign_public_key`)
* A small conditional check before the build step

This allows forks, clones, and downstream repositories to use independent signing keys without modifying tracked files.

Backward compatibility: fully preserved.

This feature is optional and does not change the behavior of existing repositories that already track `cosign.pub`.
